### PR TITLE
Feat/mel transaction chart

### DIFF
--- a/backend/ExampleLogedInUserResult.json
+++ b/backend/ExampleLogedInUserResult.json
@@ -1,0 +1,1226 @@
+{
+  "id": 1,
+  "firstname": "Max",
+  "lastname": "Mustermann",
+  "username": "max",
+  "email": "mmuster@email.ch",
+  "groups": [
+    {
+      "id": 1,
+      "name": "Mustermanns",
+      "members": [
+        {
+          "id": 2,
+          "username": "pauli",
+          "firstname": "Paul",
+          "lastname": "Mustermann",
+          "accounts": [
+            {
+              "id": 3,
+              "type": "SPAREN",
+              "saldo": 300,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "saldoLabel": "CHF 300",
+              "accountLabel": "Sparkonto von Paul",
+              "kontostandLabel": "Kontostand: 300 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "accountsList": [
+            {
+              "id": 3,
+              "type": "SPAREN",
+              "saldo": 300,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "saldoLabel": "CHF 300",
+              "accountLabel": "Sparkonto von Paul",
+              "kontostandLabel": "Kontostand: 300 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "sumOfAccountsLabel": "CHF 300",
+          "accountsLabel": "Konten von Paul",
+          "paymentLabel": "Zahlung an Paul",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        },
+        {
+          "id": 1,
+          "username": "max",
+          "firstname": "Max",
+          "lastname": "Mustermann",
+          "accounts": [
+            {
+              "id": 2,
+              "type": "TASCHENGELD",
+              "displayName": "Taschengeld",
+              "transactions": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "saldoLabel": "CHF 0",
+              "accountLabel": "Taschengeld von Max",
+              "kontostandLabel": "Kontostand: 0 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Taschengeld' überwiesen"
+            },
+            {
+              "id": 1,
+              "type": "SPAREN",
+              "saldo": 160,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "saldoLabel": "CHF 160.10",
+              "accountLabel": "Sparkonto von Max",
+              "kontostandLabel": "Kontostand: 160.10 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "accountsList": [
+            {
+              "id": 2,
+              "type": "TASCHENGELD",
+              "displayName": "Taschengeld",
+              "transactions": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "saldoLabel": "CHF 0",
+              "accountLabel": "Taschengeld von Max",
+              "kontostandLabel": "Kontostand: 0 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Taschengeld' überwiesen"
+            },
+            {
+              "id": 1,
+              "type": "SPAREN",
+              "saldo": 160,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "saldoLabel": "CHF 160.10",
+              "accountLabel": "Sparkonto von Max",
+              "kontostandLabel": "Kontostand: 160.10 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "sumOfAccountsLabel": "CHF 160",
+          "accountsLabel": "Konten von Max",
+          "paymentLabel": "Zahlung an Max",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        }
+      ],
+      "membersDescription": "2 Mitglieder",
+      "membersTitle": "Mitglieder von Mustermanns"
+    },
+    {
+      "id": 2,
+      "name": "PatentKindGroup",
+      "members": [
+        {
+          "id": 1,
+          "username": "max",
+          "firstname": "Max",
+          "lastname": "Mustermann",
+          "sumOfAccountsLabel": "CHF 0",
+          "accountsLabel": "Konten von Max",
+          "paymentLabel": "Zahlung an Max",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        }
+      ],
+      "membersDescription": "1 Mitglieder",
+      "membersTitle": "Mitglieder von PatentKindGroup"
+    }
+  ],
+  "groupsList": [
+    {
+      "id": 1,
+      "name": "Mustermanns",
+      "members": [
+        {
+          "id": 2,
+          "username": "pauli",
+          "firstname": "Paul",
+          "lastname": "Mustermann",
+          "accounts": [
+            {
+              "id": 3,
+              "type": "SPAREN",
+              "saldo": 300,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "saldoLabel": "CHF 300",
+              "accountLabel": "Sparkonto von Paul",
+              "kontostandLabel": "Kontostand: 300 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "accountsList": [
+            {
+              "id": 3,
+              "type": "SPAREN",
+              "saldo": 300,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 5,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "50",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+50"
+                },
+                {
+                  "id": 9,
+                  "createdAt": "2023-04-03T13:39:45.761281",
+                  "amount": "250",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Geburtstagsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "300",
+                  "chartLabel": "+250"
+                }
+              ],
+              "saldoLabel": "CHF 300",
+              "accountLabel": "Sparkonto von Paul",
+              "kontostandLabel": "Kontostand: 300 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "sumOfAccountsLabel": "CHF 300",
+          "accountsLabel": "Konten von Paul",
+          "paymentLabel": "Zahlung an Paul",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        },
+        {
+          "id": 1,
+          "username": "max",
+          "firstname": "Max",
+          "lastname": "Mustermann",
+          "accounts": [
+            {
+              "id": 2,
+              "type": "TASCHENGELD",
+              "displayName": "Taschengeld",
+              "transactions": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "saldoLabel": "CHF 0",
+              "accountLabel": "Taschengeld von Max",
+              "kontostandLabel": "Kontostand: 0 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Taschengeld' überwiesen"
+            },
+            {
+              "id": 1,
+              "type": "SPAREN",
+              "saldo": 160,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "saldoLabel": "CHF 160.10",
+              "accountLabel": "Sparkonto von Max",
+              "kontostandLabel": "Kontostand: 160.10 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "accountsList": [
+            {
+              "id": 2,
+              "type": "TASCHENGELD",
+              "displayName": "Taschengeld",
+              "transactions": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 2,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 6 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 3,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Taschengeld 13 Nov 2022",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+10"
+                },
+                {
+                  "id": 4,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "20",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Lego Ninjago",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-20"
+                }
+              ],
+              "saldoLabel": "CHF 0",
+              "accountLabel": "Taschengeld von Max",
+              "kontostandLabel": "Kontostand: 0 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Taschengeld' überwiesen"
+            },
+            {
+              "id": 1,
+              "type": "SPAREN",
+              "saldo": 160,
+              "displayName": "Sparkonto",
+              "transactions": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "transactionsList": [
+                {
+                  "id": 1,
+                  "createdAt": "2023-02-28T10:14:12.413401",
+                  "amount": "100.10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": false,
+                  "message": "Weihnachtsgeld",
+                  "status": "OK",
+                  "resultingSaldo": "0",
+                  "chartLabel": "+100.10"
+                },
+                {
+                  "id": 6,
+                  "createdAt": "2023-02-28T10:43:47.225581",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 7,
+                  "createdAt": "2023-02-28T10:46:18.208570",
+                  "amount": "25",
+                  "username": "pauli",
+                  "userFirstname": "Paul",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "Monatsgeld",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-25"
+                },
+                {
+                  "id": 8,
+                  "createdAt": "2023-02-28T13:38:15.085646",
+                  "amount": "10",
+                  "username": "max",
+                  "userFirstname": "Max",
+                  "userLastname": "Mustermann",
+                  "debit": true,
+                  "message": "WTF Test",
+                  "status": "processed",
+                  "resultingSaldo": "0",
+                  "chartLabel": "-10"
+                }
+              ],
+              "saldoLabel": "CHF 160.10",
+              "accountLabel": "Sparkonto von Max",
+              "kontostandLabel": "Kontostand: 160.10 CHF",
+              "paymentAccountDescription": "Der Betrag wird dem Konto 'Sparkonto' überwiesen"
+            }
+          ],
+          "sumOfAccountsLabel": "CHF 160",
+          "accountsLabel": "Konten von Max",
+          "paymentLabel": "Zahlung an Max",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        }
+      ],
+      "membersDescription": "2 Mitglieder",
+      "membersTitle": "Mitglieder von Mustermanns"
+    },
+    {
+      "id": 2,
+      "name": "PatentKindGroup",
+      "members": [
+        {
+          "id": 1,
+          "username": "max",
+          "firstname": "Max",
+          "lastname": "Mustermann",
+          "sumOfAccountsLabel": "CHF 0",
+          "accountsLabel": "Konten von Max",
+          "paymentLabel": "Zahlung an Max",
+          "amoutnLabel": "Betrag",
+          "messageLabel": "Mitteilung"
+        }
+      ],
+      "membersDescription": "1 Mitglieder",
+      "membersTitle": "Mitglieder von PatentKindGroup"
+    }
+  ],
+  "groupLabel": "Gruppen von Max"
+}

--- a/backend/src/main/kotlin/ch/levelup/kaesseli/backend/mobile/MobileService.kt
+++ b/backend/src/main/kotlin/ch/levelup/kaesseli/backend/mobile/MobileService.kt
@@ -47,6 +47,7 @@ class MobileService(
                 userUserGroup.userGroup.userUserGroups.map { userUserGroup ->
                     val member = mapUserGroupMemberDto(userUserGroup.user)
                     member.accounts = getAccountsForUserWithinGroup(userUserGroup)
+                    member.accountsList = member.accounts.toList()
                     member.sumOfAccountsLabel = getSumOfAccounts(member.accounts)
                     member.accountsLabel = "Konten von ${member.firstname}"
                     member.paymentLabel = "Zahlung an ${member.firstname}"
@@ -60,6 +61,7 @@ class MobileService(
                 uGroup.membersTitle = "Mitglieder von ${uGroup.name}"
                 //  uGroup.accounts = getAccountsForUserWithinGroup(userUserGroup);
                 logedInUser.groups.add(uGroup)
+                logedInUser.groupsList = logedInUser.groups.toList()
             }
 
             return Optional.of(logedInUser)
@@ -148,6 +150,7 @@ class MobileService(
             dboAccounts.get().forEach { accountDbo ->
                 val accountDto = mapAccount(accountDbo)
                 accountDto.transactions = getTransactionsForAccount(accountDbo)
+                accountDto.transactionsList = accountDto.transactions.toList()
                 accountDto.saldoLabel = "CHF ${accountDbo.saldo}"
                 accountDto.accountLabel =
                     "${accountDbo.displayName} von ${userUserGroup.user.firstname}"
@@ -181,7 +184,9 @@ class MobileService(
         userLastname = transaction.user.lastname,
         debit = transaction.debit,
         message = transaction.message,
-        status = transaction.status
+        status = transaction.status,
+        resultingSaldo = transaction.resultingSaldo.toString(),
+        chartLabel = if (transaction.debit) "-" + transaction.amount else "+" + transaction.amount
     )
 
     private fun mapUserDto(user: User) = LogedInUserDto(

--- a/backend/src/main/kotlin/ch/levelup/kaesseli/backend/mobile/MobileService.kt
+++ b/backend/src/main/kotlin/ch/levelup/kaesseli/backend/mobile/MobileService.kt
@@ -99,7 +99,8 @@ class MobileService(
             account = account,
             debit = newTransactionDto.debit,
             status = "recived",
-            message = newTransactionDto.message
+            message = newTransactionDto.message,
+            resultingSaldo = BigDecimal(0)
         )
         val transResponseEntity = transactionService.addTransaction(transaction)
         if(transResponseEntity.statusCode == HttpStatus.OK){
@@ -126,6 +127,7 @@ class MobileService(
             }
             account.updatedAt = LocalDateTime.now()
             accountRepository.save(account)
+            trans.resultingSaldo = account.saldo
             transactionService.setTransProcessed(trans)
         }
     }

--- a/backend/src/main/kotlin/ch/levelup/kaesseli/backend/transaction/Transaction.kt
+++ b/backend/src/main/kotlin/ch/levelup/kaesseli/backend/transaction/Transaction.kt
@@ -25,5 +25,6 @@ data class Transaction(
     val account: Account,
     val debit: Boolean,
     var status: String,
-    var message: String
+    var message: String,
+    var resultingSaldo: BigDecimal
 )

--- a/backend/src/main/resources/db/migration/V4.01__alter_table_transaction_add_resultingSaldo.sql
+++ b/backend/src/main/resources/db/migration/V4.01__alter_table_transaction_add_resultingSaldo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE transaction
+ADD COLUMN resulting_saldo DECIMAL NOT NULL DEFAULT 0;

--- a/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/AccountDto.kt
+++ b/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/AccountDto.kt
@@ -11,6 +11,7 @@ data class AccountDto(
     // add transactions
 ){
     var transactions: MutableSet<TransactionDto> = mutableSetOf()
+    var transactionsList: List<TransactionDto> = listOf()
     var saldoLabel: String = ""
     var accountLabel = ""
     var kontostandLabel = ""

--- a/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/LogedInUserDto.kt
+++ b/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/LogedInUserDto.kt
@@ -12,5 +12,6 @@ data class LogedInUserDto(
 
     ) {
     var groups: MutableSet<LogedInUserUserGroupDto> = mutableSetOf()
+    var groupsList: List<LogedInUserUserGroupDto> = listOf()
     var groupLabel = ""
 }

--- a/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/LogedInUserUserGroupDto.kt
+++ b/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/LogedInUserUserGroupDto.kt
@@ -10,7 +10,9 @@ data class LogedInUserUserGroupDto(
 ) {
     //var roles: MutableSet<RoleDto> = mutableSetOf()
     var accounts: MutableSet<AccountDto> = mutableSetOf()
+    var accountsList: List<AccountDto> = listOf()
     var members: MutableSet<UserGroupMemberDto> = mutableSetOf()
+    var membersList: List<UserGroupMemberDto> = listOf()
     var membersDescription: String = ""
     var membersTitle = ""
 }

--- a/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/TransactionDto.kt
+++ b/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/TransactionDto.kt
@@ -12,6 +12,8 @@ data class TransactionDto(
     val userLastname: String,
     val debit: Boolean,
     val message: String,
-    val status: String
+    val status: String,
+    val resultingSaldo: String,
+    val chartLabel: String
 ) {
 }

--- a/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/UserGroupMemberDto.kt
+++ b/shared/src/commonMain/kotlin/ch/levelup/kaesseli/shared/UserGroupMemberDto.kt
@@ -10,7 +10,9 @@ data class UserGroupMemberDto(
     val lastname: String = "",
 ){
     var accounts: MutableSet<AccountDto> = mutableSetOf()
+    var accountsList: List<AccountDto> = listOf()
     var roles: MutableSet<RoleDto> = mutableSetOf()
+    var rolesList: List<RoleDto> = listOf()
     var sumOfAccountsLabel: String = ""
     var accountsLabel: String = ""
     var paymentLabel: String = ""


### PR DESCRIPTION
List anstelle von Set für iOS hinzugefügt
Erweiterung um resultingSaldo bei transactions sowie chartLabel um Charts Zeichnen zu können.